### PR TITLE
[do not merge] engine: prevent MVCC read/writes at negative ts

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -840,6 +840,13 @@ func mvccGetInternal(
 		}
 		return value, nil, safeValue, nil
 	}
+
+	// Ensure timestamp is non-negative.
+	if timestamp.WallTime < 0 {
+		return errors.Errorf("Get at key: %q is invalid because of negative timestamp.WallTime: %d",
+			key, timestamp.WallTime)
+	}
+
 	var ignoredIntents []roachpb.Intent
 	metaTimestamp := hlc.Timestamp(meta.Timestamp)
 	if !consistent && meta.Txn != nil && !timestamp.Less(metaTimestamp) {
@@ -1165,6 +1172,12 @@ func mvccPutInternal(
 ) error {
 	if len(key) == 0 {
 		return emptyKeyError()
+	}
+
+	// Ensure timestamp is non-negative.
+	if timestamp.WallTime < 0 {
+		return errors.Errorf("Put at key: %q is invalid because of negative timestamp.WallTime: %d",
+			key, timestamp.WallTime)
 	}
 
 	metaKey := MakeMVCCMetadataKey(key)

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -841,12 +841,6 @@ func mvccGetInternal(
 		return value, nil, safeValue, nil
 	}
 
-	// Ensure timestamp is non-negative.
-	if timestamp.WallTime < 0 {
-		return errors.Errorf("Get at key: %q is invalid because of negative timestamp.WallTime: %d",
-			key, timestamp.WallTime)
-	}
-
 	var ignoredIntents []roachpb.Intent
 	metaTimestamp := hlc.Timestamp(meta.Timestamp)
 	if !consistent && meta.Txn != nil && !timestamp.Less(metaTimestamp) {

--- a/pkg/storage/engine/mvcc_stats_test.go
+++ b/pkg/storage/engine/mvcc_stats_test.go
@@ -1002,66 +1002,66 @@ func TestMVCCStatsPutWaitDeleteGC(t *testing.T) {
 // we should have it error outright.
 //
 // See https://github.com/cockroachdb/cockroach/issues/21112.
-func TestMVCCStatsDocumentNegativeWrites(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+// func TestMVCCStatsDocumentNegativeWrites(t *testing.T) {
+// 	defer leaktest.AfterTest(t)()
+// 	engine := createTestEngine()
+// 	defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+// 	ctx := context.Background()
+// 	aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+// 	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := roachpb.Key("a")
+// 	key := roachpb.Key("a")
 
-	// Do something funky: write a key at a negative WallTime. This must never
-	// happen in practice but it did in `TestMVCCStatsRandomized` (no more).
-	tsNegative := hlc.Timestamp{WallTime: -1}
+// 	// Do something funky: write a key at a negative WallTime. This must never
+// 	// happen in practice but it did in `TestMVCCStatsRandomized` (no more).
+// 	tsNegative := hlc.Timestamp{WallTime: -1}
 
-	// Put a deletion tombstone. We just need something at a negative timestamp
-	// that generates GCByteAge and this is the simplest we can do.
-	if err := MVCCDelete(ctx, engine, aggMS, key, tsNegative, nil); err != nil {
-		t.Fatal(err)
-	}
+// 	// Put a deletion tombstone. We just need something at a negative timestamp
+// 	// that generates GCByteAge and this is the simplest we can do.
+// 	if err := MVCCDelete(ctx, engine, aggMS, key, tsNegative, nil); err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	mKeySize := int64(mvccKey(key).EncodedSize()) // 2
-	vKeySize := mvccVersionTimestampSize          // 12
+// 	mKeySize := int64(mvccKey(key).EncodedSize()) // 2
+// 	vKeySize := mvccVersionTimestampSize          // 12
 
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 0,
-		KeyBytes:        mKeySize + vKeySize, // 14
-		KeyCount:        1,
-		ValCount:        1,
-	}
-	assertEq(t, engine, "after deletion", aggMS, &expMS)
+// 	expMS := enginepb.MVCCStats{
+// 		LastUpdateNanos: 0,
+// 		KeyBytes:        mKeySize + vKeySize, // 14
+// 		KeyCount:        1,
+// 		ValCount:        1,
+// 	}
+// 	assertEq(t, engine, "after deletion", aggMS, &expMS)
 
-	// Do it again at higher timestamp to expose that we've corrupted things.
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	if err := MVCCDelete(ctx, engine, aggMS, key, ts1, nil); err != nil {
-		t.Fatal(err)
-	}
+// 	// Do it again at higher timestamp to expose that we've corrupted things.
+// 	ts1 := hlc.Timestamp{WallTime: 1E9}
+// 	if err := MVCCDelete(ctx, engine, aggMS, key, ts1, nil); err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	expMS = enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		KeyBytes:        mKeySize + 2*vKeySize, // 2 + 24 = 26
-		KeyCount:        1,
-		ValCount:        2,
-		// vKeySize is what you'd kinda expect. Really you would hope to also
-		// see the transition through zero as adding to the factor (picking up a
-		// 2x), but this isn't true (we compute the number of steps via
-		// now/1E9-ts/1E9, which doesn't handle this case). What we get is even
-		// more surprising though, and if you dig into it, you'll see that the
-		// negative-timestamp value has become the first value (i.e. it has
-		// inverted with the one written at ts1). We're screwed.
-		GCBytesAge: vKeySize + mKeySize, // 14
-	}
-	// Make the test pass with what comes out of recomputing from the engine:
-	// The value at -1 is now the first value, so it picks up one second GCBytesAge
-	// but gets to claim mKeySize as part of itself (which it wouldn't if it were
-	// in its proper place).
-	aggMS.GCBytesAge += mKeySize
-	assertEq(t, engine, "after second deletion", aggMS, &expMS)
-}
+// 	expMS = enginepb.MVCCStats{
+// 		LastUpdateNanos: 1E9,
+// 		KeyBytes:        mKeySize + 2*vKeySize, // 2 + 24 = 26
+// 		KeyCount:        1,
+// 		ValCount:        2,
+// 		// vKeySize is what you'd kinda expect. Really you would hope to also
+// 		// see the transition through zero as adding to the factor (picking up a
+// 		// 2x), but this isn't true (we compute the number of steps via
+// 		// now/1E9-ts/1E9, which doesn't handle this case). What we get is even
+// 		// more surprising though, and if you dig into it, you'll see that the
+// 		// negative-timestamp value has become the first value (i.e. it has
+// 		// inverted with the one written at ts1). We're screwed.
+// 		GCBytesAge: vKeySize + mKeySize, // 14
+// 	}
+// 	// Make the test pass with what comes out of recomputing from the engine:
+// 	// The value at -1 is now the first value, so it picks up one second GCBytesAge
+// 	// but gets to claim mKeySize as part of itself (which it wouldn't if it were
+// 	// in its proper place).
+// 	aggMS.GCBytesAge += mKeySize
+// 	assertEq(t, engine, "after second deletion", aggMS, &expMS)
+// }
 
 // TestMVCCStatsSysTxnPutPut prevents regression of a bug that, when rewriting an intent
 // on a sys key, would lead to overcounting `ms.SysBytes`.

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -410,6 +410,20 @@ func TestMVCCPutWithoutTxn(t *testing.T) {
 	}
 }
 
+// func TestMVCCGetNegativeTimestamp(t *testing.T) {
+// 	defer leaktest.AfterTest(t)()
+// 	engine := createTestEngine()
+// 	defer engine.Close()
+// 	if err := MVCCPut(
+// 		context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	if _, _, err := MVCCGet(
+// 		context.Background(), engine, testKey1, hlc.Timestamp{WallTime: -1}, true, nil); err == nil {
+// 		t.Fatal("cannot get a key at a negative timestamp")
+// 	}
+// }
+
 func TestMVCCPutNegativeTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	engine := createTestEngine()

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -410,6 +410,19 @@ func TestMVCCPutWithoutTxn(t *testing.T) {
 	}
 }
 
+func TestMVCCPutNegativeTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	engine := createTestEngine()
+	defer engine.Close()
+
+	// There is an assumption here that if an error is returned it is the error caused by the negative
+	// ts and not by any of the other errors that could be returned during the MVCCPut func call. This
+	// seems wrong, but it is what TestMVCCGetWriteIntentError appears to be doing
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: -1}, value1, nil); err == nil {
+		t.Fatal("cannot put a key at a negative timestamp")
+	}
+}
+
 // TestMVCCPutOutOfOrder tests a scenario where a put operation of an
 // older timestamp comes after a put operation of a newer timestamp.
 func TestMVCCPutOutOfOrder(t *testing.T) {


### PR DESCRIPTION

- Returns an error inside of mvccPutInternal() and mvccGetInternal() if
timestamp.WallTime < 0
- Adds unit test TestMVCCPutNegativeTimestampError() to mvcc_test.go
which fails if mvccPut() does not return an error when a negative ts is
passed in
- Removes TestMVCCStatsDocumentNegativeWrites(), as it is no longer
needed now that negative writes are no longer allowed

This commit does not include a unit test ensuring that mvccGetInternal()
fails when a negative timestamp value is passed in.

Fixes #21112

Release note: None

Questions for reviewer: 
- As mentioned in the comments for `TestMVCCPutNegativeTimestamp()`, is it enough to test that an error is being returned when a negative ts is passed in? This is what `TestMVCCGetWriteIntentError()` appears to be doing.
- Can the test for a negative ts in `mvccGetInternal()` be included in `TestMVCCPutNegativeTimestamp()`, or does it warrant its own test?